### PR TITLE
Update README.md for better folding settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,18 @@ Tree-sitter based folding. _(Technically not a module because it's per windows a
 ```vim
 set foldmethod=expr
 set foldexpr=nvim_treesitter#foldexpr()
-set nofoldenable                     " Disable folding at startup.
+" With the above settings applied, vim will fold everything by default when
+" opening a file... setting foldlevelstart to a high value allows you to
+" start with no folds and then toggle them as desired with the za keymap.
+set foldlevelstart = 99
+```
+
+or if you prefer lua:
+
+```lua
+vim.wo.foldmethod = "expr"
+vim.wo.foldexpr = "nvim_treesitter#foldexpr()"
+vim.go.foldlevelstart = 99
 ```
 
 This will respect your `foldminlines` and `foldnestmax` settings.


### PR DESCRIPTION
I think that the README's recommended settings for enabling treesitter's folding capabilities do not reflect how most people probably want their folds to behave. The current settings make it so that when a single section of code is folded, everything folds (due to how `foldlevel` works)... most people probably want the folds to be created for them automatically, sit in the background invisibly, and then only activate when they manually toggle them. By setting `foldlevelstart`, this is achieved, and the user can still use `:set foldlevel` to batch fold if desired. Most people probably do not already have this option set, so including it in the README rather than `nofoldenable` seems like it would be a desirable change to me.